### PR TITLE
Adding support for multiple LHS, use data.table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: didimputation
 Type: Package
 Title: Imputation Estimator from Borusyak, Jaravel, and Spiess (2021)
-Version: 0.1.0
+Version: 0.2.0
 Authors@R: 
     c(person(given = "Kyle",
              family = "Butts",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Description: Estimates Two-way Fixed Effects difference-in-differences/event-stu
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 LinkingTo: 
     Rcpp,
     RcppArmadillo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ LinkingTo:
     RcppArmadillo
 Depends: 
     R (>= 2.10),
-    fixest (>= 0.9.0)
+    fixest (>= 0.10.0),
+    data.table (>= 1.10.0)
 Imports: 
     Matrix,
     magrittr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,9 +27,9 @@ Imports:
     broom,
     dplyr,
     glue,
-    methods,
-    rlang,
-    stringr
+    stringr,
+    purrr,
+    tidyr
 Suggests: 
     haven,
     testthat (>= 3.0.0)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export("%>%")
 export(did_imputation)
 import(fixest)
+import(data.table)
 importFrom(Rcpp,sourceCpp)
 importFrom(magrittr,"%>%")
 useDynLib(didimputation, .registration = TRUE)

--- a/R/data.R
+++ b/R/data.R
@@ -1,6 +1,6 @@
 #' @title Simulated data with two treatment groups and homogenous effects
 #'
-#' Generated using the following call:
+#' @description Generated using the following call:
 #'   \code{did2s::gen_data(panel = c(1990, 2020),
 #'   g1 = 2000, g2 = 2010, g3 = 0,
 #'   te1 = 2, te2 = 2, te3 = 0,
@@ -29,7 +29,7 @@
 
 #' @title Simulated data with two treatment groups and heterogenous effects
 #'
-#' Generated using the following call:
+#' @description Generated using the following call:
 #'   \code{did2s::gen_data(panel = c(1990, 2020),
 #'   g1 = 2000, g2 = 2010, g3 = 0,
 #'   te1 = 2, te2 = 1, te3 = 0,

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -18,7 +18,8 @@
 #' @import data.table
 #'
 #' @param data A `data.frame`
-#' @param yname String. Variable name for outcome. Use fixest c() syntax for multiple lhs.
+#' @param yname String. Variable name for outcome. Use `fixest` c() syntax
+#'   for multiple lhs.
 #' @param idname String. Variable name for unique unit id.
 #' @param gname String. Variable name for unit-specific date of treatment
 #'   (never-treated should be zero or `NA`).
@@ -86,224 +87,240 @@
 #' ```
 #'
 did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL,
-                          wname = NULL, wtr = NULL, horizon = NULL,
-                          pretrends = NULL, cluster_var = NULL) {
+                           wname = NULL, wtr = NULL, horizon = NULL,
+                           pretrends = NULL, cluster_var = NULL) {
 
 
-    # Set-up Parameters ------------------------------------------------------------
+  # Set-up Parameters ------------------------------------------------------------
 
-    # Extract first stage vars from formula
-    if (is.null(first_stage)) {
-        first_stage <- glue::glue("0 | {idname} + {tname}")
-    } else if(inherits(first_stage, "formula")) {
-        first_stage <- as.character(first_stage)[[2]]
-    }
+  # Extract first stage vars from formula
+  if (is.null(first_stage)) {
+    first_stage <- glue::glue("0 | {idname} + {tname}")
+  } else if (inherits(first_stage, "formula")) {
+    first_stage <- as.character(first_stage)[[2]]
+  }
 
-    # Formula for fitting the first stage
-    formula <- stats::as.formula(glue::glue("{yname} ~ {first_stage}"))
+  # Formula for fitting the first stage
+  formula <- stats::as.formula(glue::glue("{yname} ~ {first_stage}"))
 
-    # dummy estimation to extract needed variables
-    fixest_env <- feols(formula, data, lean = T, only.env = T, warn = F, notes = F)
+  # dummy estimation to extract needed variables
+  fixest_env <- feols(formula, data, lean = T, only.env = T, warn = F, notes = F)
 
-    # extract lhs vars (allows fixest style multiple lhs specification)
-    yvars <- fixest_env$lhs_names
+  # extract lhs vars (allows fixest style multiple lhs specification)
+  yvars <- fixest_env$lhs_names
 
-    # extract fe vars
-    fevars <- fixest_env$fixef_vars %>%
-        stringr::str_extract_all("\\w+") %>%
-        unlist
-    
-    # extract rhs vars
-    rhsvars <- fixest_env$linear.params %>%
-        stringr::str_split("(?<!:):(?!:)") %>%
-        unlist %>%
-        stringr::str_replace("::.*", "") %>%
-        unique
-    
-    # make local copy of data, convert to data.table
-    needed_vars <- c(yvars, gname, tname, idname, wname, wtr, rhsvars, fevars, cluster_var) %>% unique
-    data <- copy(data[, needed_vars, with = F]) %>% setDT
-    rm(fixest_env)
+  # extract fe vars
+  fevars <- fixest_env$fixef_vars %>%
+    stringr::str_extract_all("\\w+") %>%
+    unlist()
 
-    # Treatment indicator
-    data[, zz000treat := 1 * (.SD[[tname]] >= .SD[[gname]]) * (.SD[[gname]] > 0)]
-    
-    # if g is NA
-    data[is.na(zz000treat), zz000treat := 0]
+  # extract rhs vars
+  rhsvars <- fixest_env$linear.params %>%
+    stringr::str_split("(?<!:):(?!:)") %>%
+    unlist() %>%
+    stringr::str_replace("::.*", "") %>%
+    unique()
 
-    # Create event time
-    data[, zz000event_time := dplyr::if_else(is.na(.SD[[gname]]) | .SD[[gname]] == 0 | .SD[[gname]] == Inf,
-        -Inf,
-        as.numeric(.SD[[tname]] - .SD[[gname]]))]
+  # make local copy of data, convert to data.table
+  needed_vars <- c(yvars, gname, tname, idname, wname, wtr, rhsvars, fevars, cluster_var) %>% unique()
+  data <- copy(data[, needed_vars, with = F]) %>% setDT()
+  rm(fixest_env)
 
-    # Get list of event_time
-    event_time <- unique(data[, zz000event_time]) %>% purrr::keep(is.finite)
+  setDT(data)
 
-    # horizon/allhorizon options
-    if (is.null(wtr)) {
+  # Treatment indicator
+  data[, zz000treat := 1 * (.SD[[tname]] >= .SD[[gname]]) * (.SD[[gname]] > 0)]
 
-        # event-study
-        if (!is.null(horizon)) {
-            # create event time weights
+  # if g is NA
+  data[is.na(zz000treat), zz000treat := 0]
 
-            # allhorizons
-            if (all(horizon == TRUE)) horizon <- event_time
+  # Create event time
+  data[, zz000event_time := dplyr::if_else(is.na(.SD[[gname]]) | .SD[[gname]] == 0 | .SD[[gname]] == Inf,
+    -Inf,
+    as.numeric(.SD[[tname]] - .SD[[gname]])
+  )]
 
-            # Create wtr of horizons
-            wtr <- paste0("zz000wtr", event_time[event_time >= 0])
-			purrr::walk2(event_time[event_time >= 0], wtr,
-				function(e, v) data[, (v) := dplyr::if_else(is.na(zz000event_time), 0, 1 * (zz000event_time == e))])
+  # Get list of event_time
+  event_time <- unique(data[, zz000event_time]) %>% purrr::keep(is.finite)
 
-	} else {
-            wtr <- "zz000wtrtreat"
-            data[, (wtr) := 1*(zz000treat==1)]
-        }
-    }
+  # horizon/allhorizon options
+  if (is.null(wtr)) {
 
-    # Weights specified or not
-    if(is.null(wname)) {
-		data[, zz000weight := 1]
+    # event-study
+    if (!is.null(horizon)) {
+      # create event time weights
+
+      # allhorizons
+      if (all(horizon == TRUE)) horizon <- event_time
+
+      # Create wtr of horizons
+      wtr <- paste0("zz000wtr", event_time[event_time >= 0])
+      purrr::walk2(
+        event_time[event_time >= 0], wtr,
+        function(e, v) data[, (v) := dplyr::if_else(is.na(zz000event_time), 0, 1 * (zz000event_time == e))]
+      )
     } else {
-		data[, zz000weight := .SD[[wname]]]
+      wtr <- "zz000wtrtreat"
+      data[, (wtr) := 1 * (zz000treat == 1)]
+    }
+  }
+
+  # Weights specified or not
+  if (is.null(wname)) {
+    data[, zz000weight := 1]
+  } else {
+    data[, zz000weight := .SD[[wname]]]
+  }
+
+  # First Stage estimate ---------------------------------------------------------
+
+  # Estimate Y(0) using untreated observations
+  first_stage_est <- fixest::feols(formula,
+    se = "standard",
+    data[zz000treat == 0, ],
+    weights = ~zz000weight,
+    warn = FALSE, notes = FALSE
+  )
+
+  # Residualize outcome variable(s)
+  if (length(yvars) == 1) {
+    data[, (paste("zz000adj", yvars, sep = "_")) := .SD[[yname]] - stats::predict(first_stage_est, newdata = data)]
+  } else {
+    data[, (paste("zz000adj", yvars, sep = "_")) := purrr::imap(.SD, ~ .x - stats::predict(first_stage_est[lhs = .y], newdata = data)),
+      .SDcols = yvars
+    ]
+  }
+
+  # drop anything with missing values of the residualized outcome
+  todrop <- apply(is.na(data[, paste("zz000adj", yvars, sep = "_"), with = F]),
+    MARGIN = 1,
+    FUN = any
+  )
+  data <- data[!todrop, ]
+
+  data[, (wtr) := purrr::map(.SD, ~ . * zz000weight), .SDcols = wtr] # Multiply treatment weights * weights vector
+  data[is.na(zz000weight), (wtr) := 0]
+  data[, (wtr) := purrr::map(.SD, ~ . / sum(.)), .SDcols = wtr] # Normalize
+
+
+  # Point estimate for wtr
+  ests <- yvars %>%
+    purrr::set_names(yvars) %>%
+    purrr::map(function(y) data[, zz000adj := .SD[[paste("zz000adj", y, sep = "_")]]][zz000treat == 1, purrr::map(.SD, ~ sum(. * zz000adj)), .SDcols = wtr]) %>%
+    rbindlist(idcol = "lhs")
+
+  # Standard Errors --------------------------------------------------------------
+  if (length(yvars) == 1) {
+    Z <- sparse_model_matrix(data, first_stage_est)
+  } else {
+    Z <- sparse_model_matrix(data, first_stage_est[[1]])
+  }
+
+  # Equation (6) of Borusyak et. al. 2021
+  # - Z (Z_0' Z_0)^{-1} Z_1' wtr_1
+  v_star <- make_V_star(
+    (Z * data[, zz000weight]),
+    (Z * data[, zz000weight])[data$zz000treat == 0, ],
+    (Z * data[, zz000weight])[data$zz000treat == 1, ],
+    Matrix::Matrix(as.matrix(data[zz000treat == 1, wtr, with = F]), sparse = TRUE)
+  )
+
+  # fix v_it^* = w for treated observations
+  v_star[data$zz000treat == 1, ] <- as.matrix(data[zz000treat == 1, wtr, with = F])
+
+  # If no cluster_var, then use idname
+  if (is.null(cluster_var)) cluster_var <- idname
+
+  ses <- yvars %>%
+    purrr::set_names(yvars) %>%
+    purrr::map(function(y) se_inner(data[, zz000adj := .SD[[paste("zz000adj", y, sep = "_")]]], v_star, wtr, cluster_var, gname)) %>%
+    rbindlist(idcol = "lhs")
+
+
+  # Pre-event Estimates ----------------------------------------------------------
+
+  if (!is.null(pretrends)) {
+    if (all(pretrends == TRUE)) {
+      pre_formula <- stats::as.formula(glue::glue("{yname} ~ i(zz000event_time) + {first_stage}"))
+    } else {
+      if (all(pretrends %in% event_time)) {
+        pre_formula <- stats::as.formula(
+          glue::glue("{yname} ~ i(zz000event_time, keep = c({paste(pretrends, collapse = ', ')}))  + {first_stage}")
+        )
+      } else {
+        stop(glue::glue("Pretrends not found in event_time. Event_time has values {event_time}"))
+      }
     }
 
-    # First Stage estimate ---------------------------------------------------------
-
-    # Estimate Y(0) using untreated observations
-    first_stage_est <- fixest::feols(formula, se = "standard",
-                                    data[zz000treat == 0, ],
-                                    weights = ~ zz000weight,
-                                    warn = FALSE, notes = FALSE)
-
-    # Residualize outcome variable(s)
-	if (length(yvars) == 1) {
-		data[, (paste("zz000adj", yvars, sep = "_")) := .SD[[yname]] - stats::predict(first_stage_est, newdata = data)]
-	} else {
-		data[, (paste("zz000adj", yvars, sep = "_")) := purrr::imap(.SD, ~ .x - stats::predict(first_stage_est[lhs = .y], newdata = data)),
-             .SDcols = yvars]
-	}
-    
-    # drop anything with missing values of the residualized outcome
-    todrop <- apply(is.na(data[, paste("zz000adj", yvars, sep = "_"), with = F]),
-                    MARGIN = 1,
-                    FUN = any)
-    data <- data[!todrop, ]
-
-	data[, (wtr) := purrr::map(.SD, ~ . * zz000weight), .SDcols = wtr]  # Multiply treatment weights * weights vector
-	data[is.na(zz000weight), (wtr) := 0]
-	data[, (wtr) := purrr::map(.SD, ~ . / sum(.)), .SDcols = wtr] # Normalize
+    pre_est <- fixest::feols(pre_formula, data[zz000treat == 0, ], weights = ~zz000weight, warn = FALSE, notes = FALSE)
+  }
 
 
-    # Point estimate for wtr
-    ests <- yvars %>%
-        purrr::set_names(yvars) %>%
-        purrr::map(function(y) data[, zz000adj := .SD[[paste("zz000adj", y, sep = "_")]]][zz000treat == 1, purrr::map(.SD, ~ sum(. * zz000adj)), .SDcols = wtr]) %>%
-        rbindlist(idcol = "lhs")
+  # Create dataframe of results in tidy format -----------------------------------
+  ests <- ests %>%
+  	melt(id.vars = "lhs", variable.name = "term", value.name = "estimate")
+  ses <- ses %>%
+  	melt(id.vars = "lhs", variable.name = "term", value.name = "std.error")
 
-    # Standard Errors --------------------------------------------------------------
+  out <- ests[ses, on = .(lhs, term)] %>%
+    .[, term := as.character(stringr::str_replace(term, "zz000wtr", ""))] %>%
+    .[, `:=`(
+    	conf.low = estimate - 1.96 * std.error,
+    	conf.high = estimate + 1.96 * std.error
+	)]
+
+
+  if (!is.null(pretrends)) {
     if (length(yvars) == 1) {
-        Z <- sparse_model_matrix(data, first_stage_est)
+      pre_out <- broom::tidy(pre_est)
+      pre_out$lhs <- yvars
     } else {
-        Z <- sparse_model_matrix(data, first_stage_est[[1]])
+      pre_out <- pre_est %>%
+        purrr::map(broom::tidy) %>%
+        dplyr::bind_rows(.id = "lhs")
     }
 
-    # Equation (6) of Borusyak et. al. 2021
-    # - Z (Z_0' Z_0)^{-1} Z_1' wtr_1
-    v_star <- make_V_star(
-        (Z * data[, zz000weight]),
-        (Z * data[, zz000weight])[data$zz000treat == 0, ],
-        (Z * data[, zz000weight])[data$zz000treat == 1, ],
-        Matrix::Matrix(as.matrix(data[zz000treat == 1, wtr, with = F]), sparse = TRUE)
-    )
+    pre_out$term <- stringr::str_remove(pre_out$term, "zz000event_time::")
+    pre_out$term <- as.character(pre_out$term)
 
-    # fix v_it^* = w for treated observations
-    v_star[data$zz000treat == 1, ] <- as.matrix(data[zz000treat == 1, wtr, with = F])
+    pre_out$conf.low <- pre_out$estimate - 1.96 * pre_out$std.error
+    pre_out$conf.high <- pre_out$estimate + 1.96 * pre_out$std.error
 
-    # If no cluster_var, then use idname
-    if(is.null(cluster_var)) cluster_var <- idname
+    pre_out <- pre_out[, c("lhs", "term", "estimate", "std.error", "conf.low", "conf.high")]
 
-    ses <- yvars %>%
-        purrr::set_names(yvars) %>%
-        purrr::map(function(y) se_inner(data[, zz000adj := .SD[[paste("zz000adj", y, sep = "_")]]], v_star, wtr, cluster_var, gname)) %>%
-        rbindlist(idcol = "lhs")
+    out <- dplyr::bind_rows(pre_out, out)
+  }
 
-
-    # Pre-event Estimates ----------------------------------------------------------
-
-    if(!is.null(pretrends)) {
-        if(all(pretrends == TRUE)) {
-            pre_formula <- stats::as.formula(glue::glue("{yname} ~ i(zz000event_time) + {first_stage}"))
-        } else {
-            if(all(pretrends %in% event_time)) {
-                pre_formula <- stats::as.formula(
-                    glue::glue("{yname} ~ i(zz000event_time, keep = c({paste(pretrends, collapse = ', ')}))  + {first_stage}")
-                )
-            } else {
-                stop(glue::glue("Pretrends not found in event_time. Event_time has values {event_time}"))
-            }
-        }
-
-        pre_est <- fixest::feols(pre_formula, data[zz000treat == 0, ], weights = ~ zz000weight, warn=FALSE, notes=FALSE)
-    }
-
-
-    # Create dataframe of results in tidy format -----------------------------------
-    ests <- ests %>% melt(id.vars = "lhs", variable.name = "term", value.name = "estimate")
-    ses <- ses %>% melt(id.vars = "lhs", variable.name = "term", value.name = "std.error")
-
-    out <- ests[ses, on = .(lhs, term)] %>%
-        .[, term := as.character(stringr::str_replace(term, "zz000wtr", ""))] %>%
-        .[, c("conf.low", "conf.high") := .(estimate - 1.96 * std.error, estimate + 1.96 * std.error)]
-
-
-    if(!is.null(pretrends)) {
-        if (length(yvars) == 1) {
-            pre_out <- broom::tidy(pre_est)
-            pre_out$lhs <- yvars
-        } else {
-            pre_out <- pre_est %>% purrr::map(broom::tidy) %>% dplyr::bind_rows(.id = "lhs")
-        }
-
-        pre_out$term = stringr::str_remove(pre_out$term, "zz000event_time::")
-        pre_out$term = as.character(pre_out$term)
-
-        pre_out$conf.low = pre_out$estimate - 1.96 * pre_out$std.error
-        pre_out$conf.high = pre_out$estimate + 1.96 * pre_out$std.error
-
-        pre_out = pre_out[,c("lhs", "term", "estimate", "std.error", "conf.low", "conf.high")]
-
-        out = dplyr::bind_rows(pre_out, out)
-    }
-
-    return(dplyr::as_tibble(out))
+  return(dplyr::as_tibble(out))
 }
 
 
-se_inner <- function(data, v_star, wtr, cluster, gname){
-    # Calculate v_it^* = - Z (Z_0' Z_0)^{-1} Z_1' * w_1
-    vcols <- paste0("zz000v", seq_along(wtr))
-    tcols <- paste0("zz000tau_et", seq_along(wtr))
-    data[, (vcols) := split(v_star, col(v_star))]
+se_inner <- function(data, v_star, wtr, cluster, gname) {
+  # Calculate v_it^* = - Z (Z_0' Z_0)^{-1} Z_1' * w_1
+  vcols <- paste0("zz000v", seq_along(wtr))
+  tcols <- paste0("zz000tau_et", seq_along(wtr))
+  data[, (vcols) := split(v_star, col(v_star))]
 
-    # Equation (10) of Borusyak et. al. 2021
-    # Calculate tau_it - \bar{\tau}_{et}
-    data[,
-        (tcols) := purrr::map(.SD, ~ sum(.^2 * zz000adj) / sum(.^2) * zz000treat),
-        by = c(gname, "zz000event_time"),
-        .SDcols = vcols]
-    
-    # Recenter tau by \bar{\tau}_{et}
-    data[, (tcols) := purrr::map(.SD, ~ zz000adj - tidyr::replace_na(., 0)), .SDcols = tcols]
-    
-    # Equation (8)
-    # Calculate variance of estimate
-    result <- data[!is.infinite(zz000event_time), purrr::map2(vcols, tcols, ~ sum(.SD[[.x]] * .SD[[.y]])^2),
-        by = cluster] %>%
-        .[, purrr::map(.SD, ~ sqrt(sum(.))), .SDcols = paste0("V", seq_along(wtr))] %>%
-        setnames(wtr)
+  # Equation (10) of Borusyak et. al. 2021
+  # Calculate tau_it - \bar{\tau}_{et}
+  data[,
+    (tcols) := purrr::map(.SD, ~ sum(.^2 * zz000adj) / sum(.^2) * zz000treat),
+    by = c(gname, "zz000event_time"),
+    .SDcols = vcols
+  ]
 
-    data[, (c(vcols, tcols)) := NULL]
+  # Recenter tau by \bar{\tau}_{et}
+  data[, (tcols) := purrr::map(.SD, ~ zz000adj - tidyr::replace_na(., 0)), .SDcols = tcols]
 
-    return(result)
+  # Equation (8)
+  # Calculate variance of estimate
+  result <- data[!is.infinite(zz000event_time), purrr::map2(vcols, tcols, ~ sum(.SD[[.x]] * .SD[[.y]])^2),
+    by = cluster
+  ] %>%
+    .[, purrr::map(.SD, ~ sqrt(sum(.))), .SDcols = paste0("V", seq_along(wtr))] %>%
+    setnames(wtr)
 
+  data[, (c(vcols, tcols)) := NULL]
+
+  return(result)
 }

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -208,7 +208,7 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
 
     ses <- yvars %>%
         purrr::set_names(yvars) %>%
-        purrr::map(function(y) se_inner(data[, zz000adj := .SD[[paste("zz000adj", y, sep = "_")]]], wtr, cluster_var)) %>%
+        purrr::map(function(y) se_inner(data[, zz000adj := .SD[[paste("zz000adj", y, sep = "_")]]], v_star, wtr, cluster_var)) %>%
         rbindlist(idcol = "lhs")
 
 
@@ -263,7 +263,7 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
 }
 
 
-se_inner <- function(data, wtr, cluster){
+se_inner <- function(data, v_star, wtr, cluster){
     # Calculate v_it^* = - Z (Z_0' Z_0)^{-1} Z_1' * w_1
     vcols <- paste0("zz000v", seq_along(wtr))
     tcols <- paste0("zz000tau_et", seq_along(wtr))

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -80,9 +80,9 @@
 #' # Castle Data
 #' castle <- haven::read_dta("https://github.com/scunning1975/mixtape/raw/master/castle.dta")
 #'
-did_imputation(data = castle, yname = "c(l_homicide, l_assault)", gname = "effyear",
-              first_stage = ~ 0 | sid + year,
-              tname = "year", idname = "sid")
+#' did_imputation(data = castle, yname = "c(l_homicide, l_assault)", gname = "effyear",
+#'               first_stage = ~ 0 | sid + year,
+#'               tname = "year", idname = "sid")
 #' ```
 #'
 did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL,

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -80,9 +80,9 @@
 #' # Castle Data
 #' castle <- haven::read_dta("https://github.com/scunning1975/mixtape/raw/master/castle.dta")
 #'
-#' did_imputation(data = castle, yname = "c(l_homicide, l_assault)", gname = "effyear",
-#'               first_stage = ~ 0 | sid + year,
-#'               tname = "year", idname = "sid")
+did_imputation(data = castle, yname = "c(l_homicide, l_assault)", gname = "effyear",
+              first_stage = ~ 0 | sid + year,
+              tname = "year", idname = "sid")
 #' ```
 #'
 did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL,
@@ -110,7 +110,7 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
 
     # make local copy of data, convert to data.table
     needed_vars <- c(yvars, gname, tname, idname, wname, wtr, firststage_vars, cluster_var) %>% unique
-    data <- copy(data[, ..needed_vars]) %>% setDT
+    data <- copy(data[, needed_vars, with = F]) %>% setDT
 
     # Treatment indicator
     data[, zz000treat := 1 * (.SD[[tname]] >= .SD[[gname]]) * (.SD[[gname]] > 0)]
@@ -197,11 +197,11 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
         (Z * data[, zz000weight]),
         (Z * data[, zz000weight])[data$zz000treat == 0, ],
         (Z * data[, zz000weight])[data$zz000treat == 1, ],
-        Matrix::Matrix(as.matrix(data[zz000treat == 1, ..wtr]), sparse = TRUE)
+        Matrix::Matrix(as.matrix(data[zz000treat == 1, wtr, with = F]), sparse = TRUE)
     )
 
     # fix v_it^* = w for treated observations
-    v_star[data$zz000treat == 1, ] <- as.matrix(data[zz000treat == 1, ..wtr])
+    v_star[data$zz000treat == 1, ] <- as.matrix(data[zz000treat == 1, wtr, with = F])
 
     # If no cluster_var, then use idname
     if(is.null(cluster_var)) cluster_var <- idname

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -16,7 +16,7 @@
 #'
 #' @import fixest
 #' @import data.table
-#' @import tidyverse
+#' @import magrittr
 #'
 #' @param data A `data.frame`
 #' @param yname String. Variable name for outcome. Use fixest c() syntax for multiple lhs.
@@ -81,9 +81,9 @@
 #' # Castle Data
 #' castle <- haven::read_dta("https://github.com/scunning1975/mixtape/raw/master/castle.dta")
 #'
-#' did_imputation(data = castle, yname = "l_homicide", gname = "effyear",
-#'                first_stage = ~ 0 | sid + year,
-#'                tname = "year", idname = "sid")
+#' did_imputation(data = castle, yname = "c(l_homicide, l_assault)", gname = "effyear",
+#'               first_stage = ~ 0 | sid + year,
+#'               tname = "year", idname = "sid")
 #' ```
 #'
 did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL,
@@ -107,7 +107,7 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
     # extract lhs vars (allows fixest style multiple lhs specification)
     yvars <- sub("^c[(]", "", yname)
 	yvars <- sub("[)]$", "", yvars)
-	yvars <- str_split(yvars, "\\s*,\\s*")[[1]]
+	yvars <- stringr::str_split(yvars, "\\s*,\\s*")[[1]]
 
     # make local copy of data, convert to data.table
     needed_vars <- c(yvars, gname, tname, idname, wname, wtr, firststage_vars, cluster_var) %>% unique

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -103,7 +103,7 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
     formula <- stats::as.formula(glue::glue("{yname} ~ {first_stage}"))
 
     # dummy estimation to extract needed variables
-    fixest_env <- feols(formula, data, only.env = T, warn = F, notes = F)
+    fixest_env <- feols(formula, data, lean = T, only.env = T, warn = F, notes = F)
 
     # extract lhs vars (allows fixest style multiple lhs specification)
     yvars <- fixest_env$lhs_names
@@ -176,8 +176,7 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
     first_stage_est <- fixest::feols(formula, se = "standard",
                                     data[zz000treat == 0, ],
                                     weights = ~ zz000weight,
-                                    warn = FALSE, notes = FALSE,
-                                    env = fixest_env)
+                                    warn = FALSE, notes = FALSE)
 
     # Residualize outcome variable(s)
 	if (length(yvars) == 1) {

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -277,7 +277,7 @@ se_inner <- function(data, wtr, cluster){
         .SDcols = vcols]
     
     # Recenter tau by \bar{\tau}_{et}
-    data[, (tcols) := purrr::map(.SD, ~ zz000adj - replace_na(., 0)), .SDcols = tcols]
+    data[, (tcols) := purrr::map(.SD, ~ zz000adj - tidyr::replace_na(., 0)), .SDcols = tcols]
     
     # Equation (8)
     # Calculate variance of estimate

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -208,7 +208,7 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
 
     ses <- yvars %>%
         purrr::set_names(yvars) %>%
-        purrr::map(function(y) se_inner(data[, zz000adj := .SD[[paste("zz000adj", y, sep = "_")]]], v_star, wtr, cluster_var)) %>%
+        purrr::map(function(y) se_inner(data[, zz000adj := .SD[[paste("zz000adj", y, sep = "_")]]], v_star, wtr, cluster_var, gname)) %>%
         rbindlist(idcol = "lhs")
 
 
@@ -263,7 +263,7 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
 }
 
 
-se_inner <- function(data, v_star, wtr, cluster){
+se_inner <- function(data, v_star, wtr, cluster, gname){
     # Calculate v_it^* = - Z (Z_0' Z_0)^{-1} Z_1' * w_1
     vcols <- paste0("zz000v", seq_along(wtr))
     tcols <- paste0("zz000tau_et", seq_along(wtr))

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -138,7 +138,7 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
 
             # Create wtr of horizons
             wtr <- paste0("zz000wtr", event_time[event_time >= 0])
-			walk2(event_time[event_time >= 0], wtr,
+			purrr::walk2(event_time[event_time >= 0], wtr,
 				function(e, v) data[, (v) := dplyr::if_else(is.na(zz000event_time), 0, 1 * (zz000event_time == e))])
 
 	} else {

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -16,7 +16,6 @@
 #'
 #' @import fixest
 #' @import data.table
-#' @import magrittr
 #'
 #' @param data A `data.frame`
 #' @param yname String. Variable name for outcome. Use fixest c() syntax for multiple lhs.

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -121,11 +121,6 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
     stringr::str_replace("::.*", "") %>%
     unique()
 
-  # make local copy of data, convert to data.table
-  needed_vars <- c(yvars, gname, tname, idname, wname, wtr, rhsvars, fevars, cluster_var) %>% unique()
-  data <- copy(data[, needed_vars, with = F]) %>% setDT()
-  rm(fixest_env)
-
   setDT(data)
 
   # Treatment indicator

--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -124,7 +124,7 @@ did_imputation <- function(data, yname, gname, tname, idname, first_stage = NULL
         as.numeric(.SD[[tname]] - .SD[[gname]]))]
 
     # Get list of event_time
-    event_time <- unique(data[, zz000event_time]) %>% keep(is.finite)
+    event_time <- unique(data[, zz000event_time]) %>% purrr::keep(is.finite)
 
     # horizon/allhorizon options
     if (is.null(wtr)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,7 +3,7 @@ sparse_model_matrix <- function(data, fixest) {
 	Z <- NULL
 
 	# Coefficients
-	if("coefficients" %in% names(fixest)) Z <- methods::as(stats::model.matrix(fixest, data = data), "sparseMatrix")
+	if("coefficients" %in% names(fixest)) Z <- Matrix::Matrix(stats::model.matrix(fixest, data = data), sparse = T)
 
 	# Fixed Effects
 	if("fixef_id" %in% names(fixest)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,28 +1,35 @@
 # Make a sparse_model_matrix for fixest estimate. This only keeps the variables that are not removed from `fixest::feols`
-sparse_model_matrix = function(data, fixest) {
-	Z = NULL
+sparse_model_matrix <- function(data, fixest) {
+	Z <- NULL
 
 	# Coefficients
-	if("coefficients" %in% names(fixest)) Z = methods::as(stats::model.matrix(fixest, data = data), "sparseMatrix")
+	if("coefficients" %in% names(fixest)) Z <- methods::as(stats::model.matrix(fixest, data = data), "sparseMatrix")
 
 	# Fixed Effects
 	if("fixef_id" %in% names(fixest)) {
+		if (any(grepl("[\\^]", fixest$fixef_vars))) {
+			# check for interacted FE
+			interacted <- grep("[\\^]", fixest$fixef_vars, value = T)
+			de_interacted <- stringr::str_split(interacted, stringr::fixed("^"))
+
+			data[, (sub("\\^", "_", interacted)) := purrr::map(de_interacted, ~ do.call(function(...) paste(..., sep = "_"), .SD[, ., with = F]))]
+		} 
+
 		frmla <- stats::as.formula(
-			paste("~ 0 + ", paste(glue::glue("factor({all.vars(fixest$fml_all$fixef)})"), collapse = " + "))
+			paste("~ 0 +", paste(glue::glue("factor({sub('\\\\^', '_', fixest$fixef_vars)})"), collapse = " + "))
 		)
 
-		Z_fixef = Matrix::sparse.model.matrix(frmla, data = data)
+		Z_fixef <- Matrix::sparse.model.matrix(frmla, data = data)
 
-		temp = fixest::fixef(fixest)
-		select =	lapply(names(temp), function(var){
-			names = names(temp[[var]])
-			names = names[temp[[var]] != 0]
+		temp <- fixest::fixef(fixest, notes = F)
 
-			glue::glue("factor({var}){names}")
-		})
+		select <- purrr::imap(temp, function(fes, fe_name){
+			fe_levels <- names(fes)[abs(fes) > fixest$fixef.tol]
+			glue::glue("factor({sub('\\\\^', '_', fe_name)}){fe_levels}")
+			}) %>%
+			unlist
 
-
-		Z = cbind(Z, Z_fixef[, unlist(select)])
+		Z <- cbind(Z, Z_fixef[, select])
 	}
 
 	return(Z)

--- a/man/df_het.Rd
+++ b/man/df_het.Rd
@@ -3,13 +3,7 @@
 \docType{data}
 \name{df_het}
 \alias{df_het}
-\title{Simulated data with two treatment groups and heterogenous effects
-
-Generated using the following call:
-\code{did2s::gen_data(panel = c(1990, 2020),
-  g1 = 2000, g2 = 2010, g3 = 0,
-  te1 = 2, te2 = 1, te3 = 0,
-  te_m1 = 0.05, te_m2 = 0.15, te_m3 = 0)}}
+\title{Simulated data with two treatment groups and heterogenous effects}
 \format{
 A data frame with 31000 rows and 15 variables:
 \describe{
@@ -34,8 +28,6 @@ are binned.}
 df_het
 }
 \description{
-Simulated data with two treatment groups and heterogenous effects
-
 Generated using the following call:
 \code{did2s::gen_data(panel = c(1990, 2020),
   g1 = 2000, g2 = 2010, g3 = 0,

--- a/man/df_hom.Rd
+++ b/man/df_hom.Rd
@@ -3,13 +3,7 @@
 \docType{data}
 \name{df_hom}
 \alias{df_hom}
-\title{Simulated data with two treatment groups and homogenous effects
-
-Generated using the following call:
-\code{did2s::gen_data(panel = c(1990, 2020),
-  g1 = 2000, g2 = 2010, g3 = 0,
-  te1 = 2, te2 = 2, te3 = 0,
-  te_m1 = 0, te_m2 = 0, te_m3 = 0)}}
+\title{Simulated data with two treatment groups and homogenous effects}
 \format{
 A data frame with 31000 rows and 15 variables:
 \describe{
@@ -35,8 +29,6 @@ are binned.}
 df_hom
 }
 \description{
-Simulated data with two treatment groups and homogenous effects
-
 Generated using the following call:
 \code{did2s::gen_data(panel = c(1990, 2020),
   g1 = 2000, g2 = 2010, g3 = 0,

--- a/man/did_imputation.Rd
+++ b/man/did_imputation.Rd
@@ -11,7 +11,7 @@ did_imputation(
   tname,
   idname,
   first_stage = NULL,
-  weights = NULL,
+  wname = NULL,
   wtr = NULL,
   horizon = NULL,
   pretrends = NULL,
@@ -21,21 +21,22 @@ did_imputation(
 \arguments{
 \item{data}{A \code{data.frame}}
 
-\item{yname}{String. Variable name for outcome.}
+\item{yname}{String. Variable name for outcome. Use \code{fixest} c() syntax
+for multiple lhs.}
 
 \item{gname}{String. Variable name for unit-specific date of treatment
-(never-treated should be zero or \code{NA})}
+(never-treated should be zero or \code{NA}).}
 
-\item{tname}{String. Variable name for calendar period}
+\item{tname}{String. Variable name for calendar period.}
 
-\item{idname}{String. Variable name for unique unit id}
+\item{idname}{String. Variable name for unique unit id.}
 
 \item{first_stage}{Formula for Y(0).
 Formula following \code{\link[fixest:feols]{fixest::feols}}.
 Fixed effects specified after "\code{|}".
 If not specified, then just unit and time fixed effects will be used.}
 
-\item{weights}{String. Variable name for estimation weights of observations.
+\item{wname}{String. Variable name for estimation weights of observations.
 This is used in estimating Y(0) and also augments treatment effect weights.}
 
 \item{wtr}{Character vector of treatment weight names
@@ -75,53 +76,62 @@ form average treatment effects for groups of {it}.
 \section{Examples}{
 
 
-Load example dataset which has two treatment groups and homogeneous treatment effects\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Load Example Dataset
+Load example dataset which has two treatment groups and homogeneous treatment effects
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Load Example Dataset
 data("df_hom", package="did2s")
 }\if{html}{\out{</div>}}
 \subsection{Static TWFE}{
 
-You can run a static TWFE fixed effect model for a simple treatment indicator\if{html}{\out{<div class="sourceCode r">}}\preformatted{did_imputation(data = df_hom, yname = "dep_var", gname = "g",
+You can run a static TWFE fixed effect model for a simple treatment indicator
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{did_imputation(data = df_hom, yname = "dep_var", gname = "g",
                tname = "year", idname = "unit")
-#> # A tibble: 1 × 5
-#>   term  estimate std.error conf.low conf.high
-#>   <chr>    <dbl>     <dbl>    <dbl>     <dbl>
-#> 1 treat     2.02    0.0324     1.96      2.09
+#> # A tibble: 1 × 6
+#>   lhs     term  estimate std.error conf.low conf.high
+#>   <chr>   <chr>    <dbl>     <dbl>    <dbl>     <dbl>
+#> 1 dep_var treat     2.00    0.0134     1.98      2.03
 }\if{html}{\out{</div>}}
 }
 
 \subsection{Event Study}{
 
-Or you can use relative-treatment indicators to estimate an event study estimate\if{html}{\out{<div class="sourceCode r">}}\preformatted{did_imputation(data = df_hom, yname = "dep_var", gname = "g",
+Or you can use relative-treatment indicators to estimate an event study estimate
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{did_imputation(data = df_hom, yname = "dep_var", gname = "g",
                tname = "year", idname = "unit", horizon=TRUE)
-#> # A tibble: 21 × 5
-#>    term  estimate std.error conf.low conf.high
-#>    <chr>    <dbl>     <dbl>    <dbl>     <dbl>
-#>  1 0         2.12    0.0737     1.97      2.26
-#>  2 1         1.86    0.0729     1.71      2.00
-#>  3 2         1.99    0.0727     1.84      2.13
-#>  4 3         2.00    0.0763     1.86      2.15
-#>  5 4         1.95    0.0767     1.80      2.10
-#>  6 5         2.04    0.0741     1.89      2.18
-#>  7 6         2.03    0.0716     1.89      2.17
-#>  8 7         2.03    0.0743     1.88      2.17
-#>  9 8         1.98    0.0726     1.83      2.12
-#> 10 9         2.12    0.0758     1.97      2.27
+#> # A tibble: 21 × 6
+#>    lhs     term  estimate std.error conf.low conf.high
+#>    <chr>   <chr>    <dbl>     <dbl>    <dbl>     <dbl>
+#>  1 dep_var 0         1.97    0.0340     1.90      2.04
+#>  2 dep_var 1         2.05    0.0353     1.98      2.12
+#>  3 dep_var 2         2.03    0.0350     1.96      2.10
+#>  4 dep_var 3         1.97    0.0347     1.90      2.03
+#>  5 dep_var 4         1.97    0.0336     1.90      2.03
+#>  6 dep_var 5         2.03    0.0342     1.96      2.10
+#>  7 dep_var 6         2.04    0.0365     1.97      2.11
+#>  8 dep_var 7         2.00    0.0358     1.92      2.07
+#>  9 dep_var 8         2.02    0.0352     1.95      2.09
+#> 10 dep_var 9         1.96    0.0356     1.89      2.03
 #> # … with 11 more rows
 }\if{html}{\out{</div>}}
 }
 
 \subsection{Example from Cheng and Hoekstra (2013)}{
 
-Here's an example using data from Cheng and Hoekstra (2013)\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Castle Data
+Here's an example using data from Cheng and Hoekstra (2013)
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Castle Data
 castle <- haven::read_dta("https://github.com/scunning1975/mixtape/raw/master/castle.dta")
 
-did_imputation(data = castle, yname = "l_homicide", gname = "effyear",
-               first_stage = ~ 0 | sid + year,
-               tname = "year", idname = "sid")
-#> # A tibble: 1 × 5
-#>   term  estimate std.error conf.low conf.high
-#>   <chr>    <dbl>     <dbl>    <dbl>     <dbl>
-#> 1 treat   0.0798    0.0531  -0.0243     0.184
+did_imputation(data = castle, yname = "c(l_homicide, l_assault)", gname = "effyear",
+              first_stage = ~ 0 | sid + year,
+              tname = "year", idname = "sid")
+#> # A tibble: 2 × 6
+#>   lhs        term  estimate std.error conf.low conf.high
+#>   <chr>      <chr>    <dbl>     <dbl>    <dbl>     <dbl>
+#> 1 l_homicide treat   0.0798    0.0531  -0.0243     0.184
+#> 2 l_assault  treat   0.0496    0.0460  -0.0405     0.140
 }\if{html}{\out{</div>}}
 }
 }

--- a/tests/testthat/test-did_imputation.R
+++ b/tests/testthat/test-did_imputation.R
@@ -23,7 +23,7 @@ test_that("estimation runs", {
 	expect_error(did_imputation(
 		data = df_hom, yname = "dep_var", gname = "g",
 		tname = "year", idname = "unit", horizon = T, pretrends = c(-2,-1),
-		weights = "weight"),
+		wname = "weight"),
 		NA)
 	# Castle data
 	expect_error(did_imputation(


### PR DESCRIPTION
Hi Kyle - I made some modifications to your package that allow for the use of the fixest multiple lhs syntax (i.e. writing formulas like c(y1, y2) ~ x1 | z). I also changed the implementation to use data.table rather than base data frames, which should speed things up for larger data sets. Haven't done extensive testing but I match your result on the castle data set. Here's the output:

`did_imputation(data = castle, yname = "c(l_homicide, l_assault)", gname = "effyear",
                                    first_stage = ~ 0 | sid + year,
                                    tname = "year", idname = "sid")`

>     lhs  term   estimate  std.error    conf.low conf.high
> 1: l_homicide treat 0.07980155 0.05312939 -0.02433205 0.1839351
> 2: l_assault treat 0.04955260 0.04596507 -0.04053894 0.1396441