### PR TITLE
Correction to SEs

### DIFF
--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -297,7 +297,7 @@ se_inner <- function(data, v_star, wtr, cluster, gname){
     
     # Equation (8)
     # Calculate variance of estimate
-    result <- data[!is.infinite(zz000event_time), purrr::map2(vcols, tcols, ~ sum(.SD[[.x]] * .SD[[.y]])^2),
+    result <- data[, purrr::map2(vcols, tcols, ~ sum(.SD[[.x]] * .SD[[.y]])^2),
         by = cluster] %>%
         .[, purrr::map(.SD, ~ sqrt(sum(.))), .SDcols = paste0("V", seq_along(wtr))] %>%
         setnames(wtr)


### PR DESCRIPTION
I noticed there was a discrepancy in standard errors between your original code and mine in the `df_het` example. This is, I believe, because the original implementation using `split.data.frame` drops untreated observations with treatment timing set to `NA`, but does not do so if treatment time is 0. The `data.table` implementation does not have this behavior, and so I'd added a restriction to include treated units only in the calculation to match your result on the `castle` data set. Looking back at the paper, though, this is incorrect and all units should be included in the sum. This change fixes that.