### PR TITLE
adding ARMA_BIT64 in cpp

### DIFF
--- a/src/code.cpp
+++ b/src/code.cpp
@@ -1,3 +1,4 @@
+#define ARMA_64BIT_WORD 1
 #include <RcppArmadillo.h>
 // [[Rcpp::depends(RcppArmadillo)]]
 


### PR DESCRIPTION
With large datasets the command would throw the following error:

Error in make_V_star((Z * data[, zz000weight]), (Z * data[, zz000weight])[data$zz000treat ==  :
  SpMat::init(): requested size is too large; suggest to enable ARMA_64BIT_WORD

enabled ARMA_64BIT_WORD in code.cpp