### PR TITLE
remove env = ...

### DIFF
--- a/R/did_imputation.R
+++ b/R/did_imputation.R
@@ -140,8 +140,7 @@ did_imputation <- function(data, yname, gname, tname, idname,
       for(e in horizon[horizon >= 0]) {
         data[,
           paste0("zz000wtr", e) := 
-            ifelse(is.na(zz000event_time), 0, 1 * (zz000event_time == e)),
-          env = list(e = e)
+            ifelse(is.na(zz000event_time), 0, 1 * (zz000event_time == e))
         ]
       }
     } else {


### PR DESCRIPTION
The github version threw an error when estimating event study estimates, error was "ununsed argument" error from data.table. Removed "env = list(e = e)". This seems to solve the problem. Results are as in example code. Have not tested this extensively. 